### PR TITLE
Add version on peer dependencies for react-leaflet

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Ted Piotrowski",
   "license": "MIT",
   "peerDependencies": {
-    "react-leaflet": "^3.0.0"
+    "react-leaflet": "^3.0.0 | ^4.0.0"
   },
   "devDependencies": {
     "@types/leaflet": "^1.5.21",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Ted Piotrowski",
   "license": "MIT",
   "peerDependencies": {
-    "react-leaflet": "^3.0.0 | ^4.0.0"
+    "react-leaflet": "^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "@types/leaflet": "^1.5.21",


### PR DESCRIPTION
Add version `react-leaflet: "^4.0.0"` to the peer dependencies

Related to issue #5 