### PR TITLE
Fix types for VectorTileLayerProps

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,8 @@ import {
 import L, { TileLayer as LeafletTileLayer, TileLayerOptions } from 'leaflet';
 
 export interface VectorTileLayerProps extends TileLayerOptions, LayerProps {
-    styleUrl: string
+    styleUrl: any;
+    transformRequest: (url: string) => {url: string};
 }
 
 const VectorTileLayer = createTileLayerComponent<


### PR DESCRIPTION
`styleUrl` can take a complex json object, so for this use case we end up patching the type to allow `any`.

Furthermore, we require the `transformRequest` functionality which again we end up patching to avoid type errors.

These two changes would allow us to run without patching.

Thank you!